### PR TITLE
Sanitize more than two dots as well

### DIFF
--- a/server/src/main/scala/org/http4s/server/staticcontent/package.scala
+++ b/server/src/main/scala/org/http4s/server/staticcontent/package.scala
@@ -23,7 +23,7 @@ package object staticcontent {
   def webjarService[F[_]: Sync](config: WebjarService.Config[F]): HttpService[F] =
     WebjarService(config)
 
-  private[staticcontent] val sanitize = "\\.\\.".r.replaceAllIn(_: String, ".")
+  private[staticcontent] val sanitize = "\\.+".r.replaceAllIn(_: String, ".")
 
   private[staticcontent] val AcceptRangeHeader = `Accept-Ranges`(RangeUnit.Bytes)
 

--- a/server/src/test/scala/org/http4s/server/staticcontent/SanitizeSpec.scala
+++ b/server/src/test/scala/org/http4s/server/staticcontent/SanitizeSpec.scala
@@ -1,0 +1,21 @@
+package org.http4s.server.staticcontent
+
+import org.http4s.Http4sSpec
+
+class SanitizeSpec extends Http4sSpec {
+
+  "staticcontent.sanitize" should {
+    "replace .. with . in paths" in {
+      val path = "../../bin/sh"
+
+      sanitize(path) must_=== "././bin/sh"
+    }
+
+    "replace ... with . in paths" in {
+      val path = "../.../bin/sh"
+
+      sanitize(path) must_=== "././bin/sh"
+    }
+  }
+
+}


### PR DESCRIPTION
`org.http4s.server.staticcontent.sanitize` is supposed to protect against getting arbitrary files in static services by replacing `..` with `.`. However, if you pass it `...` it will replace it with `..`.

This PR replaces an arbitrary number of periods with a single.